### PR TITLE
fix: add dependabot ignore rules for major terraform provider bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      ignore:
+        - dependency-name: "hashicorp/*"
+          update-types: ["version-update:semver-major"]
+        - dependency-name: "microsoft/*"
+          update-types: ["version-update:semver-major"]
+        - dependency-name: "azure/*"
+          update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Adds ignore rules to `.github/dependabot.yml` to prevent dependabot from proposing **major** version bumps for terraform providers:

- `hashicorp/*`
- `microsoft/*`
- `azure/*`

Major version bumps consistently break required CI checks due to breaking API changes and need manual migration work. Minor and patch updates will continue as normal.

## Changes

Only `.github/dependabot.yml` is modified — no code changes.