### PR TITLE
implement identity-based endpoint routing with RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ If `make check` target is successful, developer is good to commit the code to pr
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.117.1 |
 
 ## Modules
 
@@ -122,6 +124,7 @@ No providers.
 | <a name="module_resource_names"></a> [resource\_names](#module\_resource\_names) | terraform.registry.launch.nttdata.com/module_library/resource_name/launch | ~> 2.0 |
 | <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm | ~> 1.1 |
 | <a name="module_iothub"></a> [iothub](#module\_iothub) | terraform.registry.launch.nttdata.com/module_primitive/iothub/azurerm | ~> 1.0 |
+| <a name="module_iothub_eventhub_data_sender"></a> [iothub\_eventhub\_data\_sender](#module\_iothub\_eventhub\_data\_sender) | terraform.registry.launch.nttdata.com/module_primitive/role_assignment/azurerm | ~> 1.0 |
 | <a name="module_iothub_dps"></a> [iothub\_dps](#module\_iothub\_dps) | terraform.registry.launch.nttdata.com/module_primitive/iothub_dps/azurerm | ~> 1.0 |
 | <a name="module_eventhub_namespace"></a> [eventhub\_namespace](#module\_eventhub\_namespace) | terraform.registry.launch.nttdata.com/module_primitive/eventhub_namespace/azurerm | 1.1.4 |
 | <a name="module_eventhub_namespace_private_endpoint"></a> [eventhub\_namespace\_private\_endpoint](#module\_eventhub\_namespace\_private\_endpoint) | terraform.registry.launch.nttdata.com/module_primitive/private_endpoint/azurerm | ~> 1.0 |
@@ -135,7 +138,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [azurerm_iothub.iothub_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/iothub) | data source |
 
 ## Inputs
 
@@ -165,6 +170,10 @@ No resources.
 | <a name="input_enrichments"></a> [enrichments](#input\_enrichments) | (Optional) A map of enrichments and their respective properties<br/>    object({<br/>      key (as map key) = (Required) The key of the enrichment.<br/>      value            = (Required) The value of the enrichment. Value can be any static string, the name of the IoT Hub sending the message (use $iothubname) or information from the device twin (ex: $twin.tags.latitude)<br/>      endpoint\_names   = (Required) The list of endpoints which will be enriched.<br/>    }) | <pre>map(object({<br/>    value          = string<br/>    endpoint_names = list(string)<br/>  }))</pre> | `{}` | no |
 | <a name="input_cloud_to_device"></a> [cloud\_to\_device](#input\_cloud\_to\_device) | (Optional) An object for cloud-to-device messaging properties.<br/>    object({<br/>      max\_delivery\_count = (Optional) The maximum delivery count for cloud-to-device per-device queues. This value must be between 1 and 100. Defaults to 10.<br/>      default\_ttl        = (Optional) The default time to live for cloud-to-device messages, specified as an ISO 8601 timespan duration. This value must be between 1 minute and 48 hours. Defaults to PT1H.<br/>      feedback = object({<br/>        time\_to\_live       = (Optional) The retention time for service-bound feedback messages, specified as an ISO 8601 timespan duration. This value must be between 1 minute and 48 hours. Defaults to PT1H.<br/>        max\_delivery\_count = (Optional) The maximum delivery count for the feedback queue. This value must be between 1 and 100. Defaults to 10.<br/>        lock\_duration      = (Optional) The lock duration for the feedback queue, specified as an ISO 8601 timespan duration. This value must be between 5 and 300 seconds. Defaults to PT60S.<br/>    }) | <pre>object({<br/>    max_delivery_count = number<br/>    default_ttl        = string<br/>    feedback = object({<br/>      time_to_live       = string<br/>      max_delivery_count = number<br/>      lock_duration      = string<br/>    })<br/>  })</pre> | `null` | no |
 | <a name="input_consumer_groups"></a> [consumer\_groups](#input\_consumer\_groups) | (Optional) A map of consumer groups and their respective properties."<br/>    map(object({<br/>      name (as map key)      = (Required) The name of this Consumer Group.<br/>      eventhub\_endpoint\_name = (Required) The name of the Event Hub-compatible endpoint in the IoT hub.<br/>    })) | <pre>map(object({<br/>    eventhub_endpoint_name = string<br/>  }))</pre> | `{}` | no |
+| <a name="input_generate_eventhub_endpoints_from_eventhubs"></a> [generate\_eventhub\_endpoints\_from\_eventhubs](#input\_generate\_eventhub\_endpoints\_from\_eventhubs) | (Optional) Whether to automatically generate IoT Hub custom endpoints from eventhubs map. When false, only explicit endpoints map is used. Defaults to true for backward compatibility. | `bool` | `true` | no |
+| <a name="input_generate_eventhub_routes_from_eventhubs"></a> [generate\_eventhub\_routes\_from\_eventhubs](#input\_generate\_eventhub\_routes\_from\_eventhubs) | (Optional) Whether to automatically generate IoT Hub routes from eventhubs map. When false, only explicit routes map is used. Defaults to true for backward compatibility. | `bool` | `true` | no |
+| <a name="input_grant_iothub_eventhub_data_sender_role"></a> [grant\_iothub\_eventhub\_data\_sender\_role](#input\_grant\_iothub\_eventhub\_data\_sender\_role) | (Optional) Whether to grant IoT Hub system-assigned identity Azure Event Hubs Data Sender role on Event Hub namespace. Required for identity-based custom endpoints. Defaults to false. | `bool` | `false` | no |
+| <a name="input_eventhub_data_sender_scope"></a> [eventhub\_data\_sender\_scope](#input\_eventhub\_data\_sender\_scope) | (Optional) Scope for the Event Hubs Data Sender role assignment. If not provided, defaults to Event Hub namespace ID. Should be Event Hub namespace ID or specific Event Hub ID. | `string` | `null` | no |
 | <a name="input_allocation_policy"></a> [allocation\_policy](#input\_allocation\_policy) | (Optional) The allocation policy of the IoT Device Provisioning Service (Hashed, GeoLatency or Static). Defaults to Hashed. | `string` | `"Hashed"` | no |
 | <a name="input_data_residency_enabled"></a> [data\_residency\_enabled](#input\_data\_residency\_enabled) | Optional) Specifies if the IoT Device Provisioning Service has data residency and disaster recovery enabled. Defaults to false. | `bool` | `false` | no |
 | <a name="input_dps_sku"></a> [dps\_sku](#input\_dps\_sku) | (Required) The pricing tier for the IoT Device Provisioning Service.<br/>    object({<br/>      name     = (Required) The name of the sku. Currently can only be set to S1.<br/>      capacity = (Required) The number of provisioned IoT Device Provisioning Service units. Currently set to 1.<br/>    }) | <pre>object({<br/>    name     = string<br/>    capacity = number<br/>  })</pre> | <pre>{<br/>  "capacity": 1,<br/>  "name": "S1"<br/>}</pre> | no |
@@ -204,6 +213,7 @@ No resources.
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | The resource group for the reference Iot Hub. |
 | <a name="output_iothub_id"></a> [iothub\_id](#output\_iothub\_id) | The IoT Hub Id. |
 | <a name="output_iothub_name"></a> [iothub\_name](#output\_iothub\_name) | The IoT Hub Name. |
+| <a name="output_iothub_principal_id"></a> [iothub\_principal\_id](#output\_iothub\_principal\_id) | The principal ID of the IoT Hub system-assigned managed identity. Used for RBAC role assignments. |
 | <a name="output_iothub_dps_id"></a> [iothub\_dps\_id](#output\_iothub\_dps\_id) | The IoT Hub Device Provisioning Service Id. |
 | <a name="output_iothub_dps_name"></a> [iothub\_dps\_name](#output\_iothub\_dps\_name) | The IoT Hub Device Provisioning Service Name. |
 | <a name="output_scope_id"></a> [scope\_id](#output\_scope\_id) | The IoT Hub Device Provisioning Service Scope Id. |

--- a/main.tf
+++ b/main.tf
@@ -51,26 +51,32 @@ module "iothub" {
   event_hub_partition_count     = var.event_hub_partition_count
   event_hub_retention_in_days   = var.event_hub_retention_in_days
   public_network_access_enabled = var.public_network_access_enabled
-  endpoints = merge(var.endpoints, {
-    for key, eventhub in var.eventhubs : key => {
-      type              = eventhub.endpoint_type
-      connection_string = module.eventhub_auth_rules[key].auth_rule_primary_connection_string
-    }
-    if eventhub.endpoint_type != null
-  })
+  endpoints = merge(
+    var.generate_eventhub_endpoints_from_eventhubs ? {
+      for key, eventhub in var.eventhubs : key => {
+        type              = eventhub.endpoint_type
+        connection_string = module.eventhub_auth_rules[key].auth_rule_primary_connection_string
+      }
+      if eventhub.endpoint_type != null
+    } : {},
+    var.endpoints
+  )
   fallback_route   = var.fallback_route
   file_uploads     = var.file_uploads
   identity         = var.identity
   network_rule_set = var.network_rule_set
-  routes = merge(var.routes, {
-    for key, eventhub in var.eventhubs : key => {
-      endpoint_names = [key]
-      source         = eventhub.route.source
-      condition      = eventhub.route.condition
-      enabled        = eventhub.route.enabled
-    }
-    if eventhub.route != null
-  })
+  routes = merge(
+    var.generate_eventhub_routes_from_eventhubs ? {
+      for key, eventhub in var.eventhubs : key => {
+        endpoint_names = [key]
+        source         = eventhub.route.source
+        condition      = eventhub.route.condition
+        enabled        = eventhub.route.enabled
+      }
+      if eventhub.route != null
+    } : {},
+    var.routes
+  )
   enrichments     = var.enrichments
   cloud_to_device = var.cloud_to_device
   consumer_groups = var.consumer_groups
@@ -78,6 +84,28 @@ module "iothub" {
 
   tags       = merge(local.tags, { resource_name = module.resource_names["iothub"].standard })
   depends_on = [module.resource_group, module.eventhub, module.eventhub_auth_rules]
+}
+
+data "azurerm_iothub" "iothub_identity" {
+  count = var.grant_iothub_eventhub_data_sender_role && var.identity.identity_type == "SystemAssigned" ? 1 : 0
+
+  name                = module.iothub.name
+  resource_group_name = coalesce(var.resource_group_name, module.resource_names["resource_group"].standard)
+
+  depends_on = [module.iothub]
+}
+
+module "iothub_eventhub_data_sender" {
+  source  = "terraform.registry.launch.nttdata.com/module_primitive/role_assignment/azurerm"
+  version = "~> 1.0"
+
+  count = var.grant_iothub_eventhub_data_sender_role && var.identity.identity_type == "SystemAssigned" ? 1 : 0
+
+  scope                = coalesce(var.eventhub_data_sender_scope, try(module.eventhub_namespace[0].namespace_id, null))
+  role_definition_name = "Azure Event Hubs Data Sender"
+  principal_id         = data.azurerm_iothub.iothub_identity[0].identity[0].principal_id
+
+  depends_on = [module.iothub, module.eventhub_namespace, data.azurerm_iothub.iothub_identity]
 }
 
 module "iothub_dps" {

--- a/main.tf
+++ b/main.tf
@@ -83,16 +83,13 @@ module "iothub" {
   min_tls_version = var.min_tls_version
 
   tags       = merge(local.tags, { resource_name = module.resource_names["iothub"].standard })
-  depends_on = [module.resource_group, module.eventhub, module.eventhub_auth_rules]
+  depends_on = [module.resource_group, module.eventhub, module.eventhub_auth_rules, module.iothub_eventhub_data_sender]
 }
-
 data "azurerm_iothub" "iothub_identity" {
   count = var.grant_iothub_eventhub_data_sender_role && var.identity.identity_type == "SystemAssigned" ? 1 : 0
 
-  name                = module.iothub.name
+  name                = module.resource_names["iothub"].standard
   resource_group_name = coalesce(var.resource_group_name, module.resource_names["resource_group"].standard)
-
-  depends_on = [module.iothub]
 }
 
 module "iothub_eventhub_data_sender" {
@@ -105,7 +102,7 @@ module "iothub_eventhub_data_sender" {
   role_definition_name = "Azure Event Hubs Data Sender"
   principal_id         = data.azurerm_iothub.iothub_identity[0].identity[0].principal_id
 
-  depends_on = [module.iothub, module.eventhub_namespace, data.azurerm_iothub.iothub_identity]
+  depends_on = [data.azurerm_iothub.iothub_identity, module.eventhub_namespace]
 }
 
 module "iothub_dps" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,6 +25,11 @@ output "iothub_name" {
   value       = module.iothub.name
 }
 
+output "iothub_principal_id" {
+  description = "The principal ID of the IoT Hub system-assigned managed identity. Used for RBAC role assignments."
+  value       = try(data.azurerm_iothub.iothub_identity[0].identity[0].principal_id, null)
+}
+
 output "iothub_dps_id" {
   description = "The IoT Hub Device Provisioning Service Id."
   value       = module.iothub_dps.id

--- a/variables.tf
+++ b/variables.tf
@@ -344,6 +344,32 @@ variable "consumer_groups" {
   default = {}
 }
 
+# IoT Hub Endpoint and Route Generation Control
+variable "generate_eventhub_endpoints_from_eventhubs" {
+  description = "(Optional) Whether to automatically generate IoT Hub custom endpoints from eventhubs map. When false, only explicit endpoints map is used. Defaults to true for backward compatibility."
+  type        = bool
+  default     = true
+}
+
+variable "generate_eventhub_routes_from_eventhubs" {
+  description = "(Optional) Whether to automatically generate IoT Hub routes from eventhubs map. When false, only explicit routes map is used. Defaults to true for backward compatibility."
+  type        = bool
+  default     = true
+}
+
+# IoT Hub RBAC Configuration
+variable "grant_iothub_eventhub_data_sender_role" {
+  description = "(Optional) Whether to grant IoT Hub system-assigned identity Azure Event Hubs Data Sender role on Event Hub namespace. Required for identity-based custom endpoints. Defaults to false."
+  type        = bool
+  default     = false
+}
+
+variable "eventhub_data_sender_scope" {
+  description = "(Optional) Scope for the Event Hubs Data Sender role assignment. If not provided, defaults to Event Hub namespace ID. Should be Event Hub namespace ID or specific Event Hub ID."
+  type        = string
+  default     = null
+}
+
 # Device Provisioning Service Properties
 variable "allocation_policy" {
   type        = string


### PR DESCRIPTION
## Summary
Implement support for identity-based Event Hub endpoint routing in IoT Hub reference module, 
enabling system-assigned managed identity + RBAC authentication for Event Hub connections 
(required for Event Hub firewall with trustedServices enabled).

## Changes
- **Conditional Endpoint Generation**: Added `generate_eventhub_endpoints_from_eventhubs` flag 
  to disable auto-generation of keyBased endpoints, allowing custom identity-based endpoints to override
- **Conditional Route Generation**: Added `generate_eventhub_routes_from_eventhubs` flag 
  to disable auto-generation of routes for customization  
- **RBAC Assignment**: Added optional Event Hubs Data Sender role assignment for IoT Hub MI
  - Scoped to Event Hub namespace (or custom scope)
  - Requires system-assigned identity enabled on IoT Hub
  - Opt-in via `grant_iothub_eventhub_data_sender_role` flag
- **Merge Logic**: Reordered merge operations so custom endpoint/route maps override generated maps
- **Output**: Exposed `iothub_principal_id` for RBAC role assignment tracking

## Backward Compatibility
✅ All new variables default to preserve existing behavior:
- `generate_eventhub_endpoints_from_eventhubs = true` (auto-generate as before)
- `generate_eventhub_routes_from_eventhubs = true` (auto-generate as before)
- `grant_iothub_eventhub_data_sender_role = false` (no RBAC by default)

## Fixes
- Resolves Event Hub firewall blocking key-based endpoint connections
  (identity-based auth + RBAC required for trustedServices exception)